### PR TITLE
List services pagination fix. Not hiding when there are no more services to display

### DIFF
--- a/dashboard/src/views/ServiceDiscovery/ListServices.vue
+++ b/dashboard/src/views/ServiceDiscovery/ListServices.vue
@@ -39,7 +39,7 @@
           </div>
         </div>
       </div>
-      <div class="row" v-if="services.length >= 10">
+      <div class="row">
         <div class="col-sm-2 offset-sm-5 text-center">
           <nav aria-label="...">
             <ul class="pagination">
@@ -55,8 +55,8 @@
               <li class="page-item" v-if="services.length === 10">
                 <a class="page-link" href="#" @click="currentPage += 1" >{{ currentPage + 1}}</a>
               </li>
-              <li class="page-item">
-                <a class="page-link"  v-if="services.length === 10" @click="currentPage += 1" href="#">Next</a>
+              <li :class="'page-item' + ((services.length < 10) ? ' disabled' : '')">
+                <a class="page-link" @click="currentPage += 1" href="#">Next</a>
               </li>
             </ul>
           </nav>


### PR DESCRIPTION
When there were no more services to display the pagination was being hidden. Not allowing to navigate.